### PR TITLE
Added ec2:DescribeAccountAttributes

### DIFF
--- a/templates/fncm-deployment.template.yaml
+++ b/templates/fncm-deployment.template.yaml
@@ -1292,6 +1292,9 @@ Resources:
             Action: 'ec2:DescribeInstances'
             Resource: '*'
           - Effect: Allow
+            Action: 'ec2:DescribeAccountAttributes'
+            Resource: '*'
+          - Effect: Allow
             Action: 'ec2:DescribeInstanceStatus'
             Resource: '*'
           - Effect: Allow


### PR DESCRIPTION
*Issue #* There isn't an issue number, but I was working with one of our customers trying to deploy the IBM FileNet Content Manager Quickstart and encountered "...failed to create LoadBalancer due to AccessDenied"Use: arn:aws:sts::099945672290:assumed-role/IBM-FileNet-Content-Manager-EKSSt-NodeInstanceRole-1UY5SUFS3IFI3/i-039e05e79eef57a63 is not authorized to perform: ec2:DescribeAccountAttributes"

*Description of changes:*

Added:  ec2:DescribeAccountAttributes to the policy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
